### PR TITLE
Add a timer to flush the debug log.

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -30,6 +30,11 @@ static const char *SeverityStr(int severity) {
   }
 }
 
+void logging_timer_cb(struct ev_loop *loop, ev_timer *w, int revents) {
+  if (logf)
+    fflush(logf);
+}
+
 void logging_init(int fd, int level) {
   if (logf)
     fclose(logf);

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,12 +1,17 @@
 #ifndef _LOGGING_H_
 #define _LOGGING_H_
 
+#include <ev.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 // Initializes logging.
 // Writes logs to descriptor 'fd' for log levels above or equal to 'level'.
 void logging_init(int fd, int level);
+
+// Periodic timer to flush logs.
+void logging_timer_cb(struct ev_loop *loop, ev_timer *w, int revents);
 
 // Cleans up and flushes open logs.
 void logging_cleanup();

--- a/src/main.c
+++ b/src/main.c
@@ -182,6 +182,10 @@ int main(int argc, char *argv[]) {
   ev_signal_init(&sigint, sigint_cb, SIGINT);
   ev_signal_start(loop, &sigint);
 
+  ev_timer logging_timer;
+  ev_timer_init(&logging_timer, logging_timer_cb, 0, 10);
+  ev_timer_start(loop, &logging_timer);
+
   dns_poller_t dns_poller;
   dns_poller_init(&dns_poller, loop, opt.bootstrap_dns, "dns.google.com",
                   120 /* seconds */, dns_poll_cb, &app.resolv);


### PR DESCRIPTION
When debug logging is enabled debug-level messages are not flushed,
presumably to keep the overhead down.  This means that debug messages
can end up not being shown until either a more severe error happens or
the server gets shut down.  This adds a timer that flushes the log
every ten seconds.  (This is set up after logging_init since the log
may be needed during the event loop setup.)

Fixes https://github.com/aarond10/https_dns_proxy/issues/19