### PR TITLE
Avoid log flush timer where possible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,13 @@ Usage: https_dns_proxy [-a <listen_addr>] [-p <listen_port>]
   -u user           User to drop to launched as root. (nobody)
   -g group          Group to drop to launched as root. (nobody)
   -b dns_servers    Comma separated IPv4 address of DNS servers
-                    to resolve dns.google.com. (8.8.8.8,8.8.4.4)
+                    to resolve dns.google.com. (8.8.8.8,8.8.4.4,145.100.185.15,
+                    145.100.185.16,185.49.141.37,199.58.81.218,80.67.188.188)
   -t proxy_server   Optional HTTP proxy. e.g. socks5://127.0.0.1:1080
                     (Initial DNS resolution can't be done over this.)
   -l logfile        Path to file to log to. (-)
+  -x                Use HTTP/1.1 instead of HTTP/2. Useful with broken
+                    or limited builds of libcurl (false).
   -v                Increase logging verbosity. (INFO)
 ```
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -9,8 +9,12 @@
 
 #include "logging.h"
 
+/* logs of this severity or higher are flushed immediately after write */
+#define LOG_FLUSH_LEVEL LOG_WARNING
+
 static FILE *logf = NULL;
 static int loglevel = LOG_ERROR;
+static ev_timer logging_timer;
 
 // Renders a severity as a short string.
 static const char *SeverityStr(int severity) {
@@ -31,10 +35,20 @@ static const char *SeverityStr(int severity) {
   }
 }
 
-void logging_timer_cb(struct ev_loop *loop, ev_timer *w, int revents) {
+static void logging_timer_cb(struct ev_loop *loop, ev_timer *w, int revents) {
   if (logf) {
     fflush(logf);
   }
+}
+
+void logging_flush_init(struct ev_loop *loop) {
+  /* don't init timer if we will never write messages that are not flushed */
+  if (loglevel >= LOG_FLUSH_LEVEL) {
+    return;
+  }
+  DLOG("initializing periodic log flush timer");
+  ev_timer_init(&logging_timer, logging_timer_cb, 0, 10);
+  ev_timer_start(loop, &logging_timer);
 }
 
 void logging_init(int fd, int level) {
@@ -81,7 +95,7 @@ void _log(const char *file, int line, int severity, const char *fmt, ...) {
   va_end(args);
   fprintf(logf, "\n");
 
-  if (severity >= LOG_WARNING) {
+  if (severity >= LOG_FLUSH_LEVEL) {
     fflush(logf);
   }
   if (severity == LOG_FATAL) {

--- a/src/logging.c
+++ b/src/logging.c
@@ -55,7 +55,7 @@ void logging_cleanup() {
 void _log(const char *file, int line, int severity, const char *fmt, ...) {
   if (severity < loglevel) {
     return;
-}
+  }
 
   if (!logf) {
     logf = fdopen(STDOUT_FILENO, "w");
@@ -68,7 +68,7 @@ void _log(const char *file, int line, int severity, const char *fmt, ...) {
   }
   if (*filename == '/') {
     filename++;
-}
+  }
 
   struct timeval tv;
   gettimeofday(&tv, NULL);
@@ -83,8 +83,8 @@ void _log(const char *file, int line, int severity, const char *fmt, ...) {
 
   if (severity >= LOG_WARNING) {
     fflush(logf);
-}
+  }
   if (severity == LOG_FATAL) {
     exit(1);
-}
+  }
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -10,8 +10,8 @@ extern "C" {
 // Writes logs to descriptor 'fd' for log levels above or equal to 'level'.
 void logging_init(int fd, int level);
 
-// Periodic timer to flush logs.
-void logging_timer_cb(struct ev_loop *loop, ev_timer *w, int revents);
+// Initialize periodic timer to flush logs.
+void logging_flush_init(struct ev_loop *loop);
 
 // Cleans up and flushes open logs.
 void logging_cleanup();

--- a/src/main.c
+++ b/src/main.c
@@ -184,9 +184,7 @@ int main(int argc, char *argv[]) {
   ev_signal_init(&sigint, sigint_cb, SIGINT);
   ev_signal_start(loop, &sigint);
 
-  ev_timer logging_timer;
-  ev_timer_init(&logging_timer, logging_timer_cb, 0, 10);
-  ev_timer_start(loop, &logging_timer);
+  logging_flush_init(loop);
 
   dns_poller_t dns_poller;
   dns_poller_init(&dns_poller, loop, opt.bootstrap_dns, "dns.google.com",


### PR DESCRIPTION
Log messages of severity WARNING or higher are always flushed after
being written, so if we do not emit messages below that severity (which
is the common case) then there is no need for the periodic flush calls.