### PR TITLE
Use proxy remote name resolution if possible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ Usage: https_dns_proxy [-a <listen_addr>] [-p <listen_port>]
   -b dns_servers    Comma separated IPv4 address of DNS servers
                     to resolve dns.google.com. (8.8.8.8,8.8.4.4)
   -t proxy_server   Optional HTTP proxy. e.g. socks5://127.0.0.1:1080
-                    (Initial DNS resolution can't be done over this.)
+                    Remote name resolution will be used if the protocol
+                    supports it (http, https, socks4a, socks5h), otherwise
+                    initial DNS resolution will still be done via the
+                    bootstrap DNS servers.
   -l logfile        Path to file to log to. (-)
   -v                Increase logging verbosity. (INFO)
 ```

--- a/src/main.c
+++ b/src/main.c
@@ -122,6 +122,20 @@ static void dns_poll_cb(void *data, struct sockaddr_in *addr) {
   *resolv = curl_slist_append(NULL, buf);
 }
 
+static int proxy_supports_name_resolution(const char *proxy)
+{
+  int i;
+  const char *ptypes[] = {"http:", "https:", "socks4a:", "socks5h:"};
+
+  if (proxy == NULL)
+    return 0;
+  for (i = 0; i < sizeof(ptypes) / sizeof(*ptypes); i++) {
+    if (strncasecmp(proxy, ptypes[i], strlen(ptypes[i])) == 0)
+      return 1;
+  }
+  return 0;
+}
+
 int main(int argc, char *argv[]) {
   struct Options opt;
   options_init(&opt);
@@ -189,12 +203,15 @@ int main(int argc, char *argv[]) {
   ev_timer_start(loop, &logging_timer);
 
   dns_poller_t dns_poller;
-  dns_poller_init(&dns_poller, loop, opt.bootstrap_dns, "dns.google.com",
-                  120 /* seconds */, dns_poll_cb, &app.resolv);
+  if (!proxy_supports_name_resolution(opt.curl_proxy)) {
+    dns_poller_init(&dns_poller, loop, opt.bootstrap_dns, "dns.google.com",
+                    120 /* seconds */, dns_poll_cb, &app.resolv);
+  }
 
   ev_run(loop, 0);
 
-  dns_poller_cleanup(&dns_poller);
+  if (!proxy_supports_name_resolution(opt.curl_proxy))
+    dns_poller_cleanup(&dns_poller);
 
   curl_slist_free_all(app.resolv);
 

--- a/src/options.c
+++ b/src/options.c
@@ -122,7 +122,10 @@ void options_show_usage(int argc, char **argv) {
   printf("                    to resolve dns.google.com. (%s)\n",
          defaults.bootstrap_dns);
   printf("  -t proxy_server   Optional HTTP proxy. e.g. socks5://127.0.0.1:1080\n");
-  printf("                    (Initial DNS resolution can't be done over this.)\n");
+  printf("                    Remote name resolution will be used if the protocol\n");
+  printf("                    supports it (http, https, socks4a, socks5h), otherwise\n");
+  printf("                    initial DNS resolution will still be done via the\n");
+  printf("                    bootstrap DNS servers.\n");
   printf("  -l logfile        Path to file to log to. (%s)\n",
          defaults.logfile);
   printf("  -x                Use HTTP/1.1 instead of HTTP/2. Useful with broken\n"


### PR DESCRIPTION
Many of the protocols supported by libcurl support remote name
resolution.  When those are in use, do not attempt local resolution of
dns.google.com and instead leave it to the proxy to resolve.  This may
result in better performance if the proxy gets a closer address for
the server.

See https://github.com/aarond10/https_dns_proxy/issues/12