### PR TITLE
Dynamically adjust DNS bootstrap interval during runtime

### DIFF
--- a/src/dns_poller.h
+++ b/src/dns_poller.h
@@ -4,6 +4,12 @@
 #include <ares.h>
 #include <ev.h>
 
+// Due to c-ares not playing nicely with libev, the intervals below also
+// wind up functioning as the timeout values after which any pending
+// queries are cancelled and treated as if they've failed.
+#define POLLER_INTVL_NORM 120
+#define POLLER_INTVL_ERR 5
+
 // Callback to be called periodically when we get a valid DNS response.
 typedef void (*dns_poller_cb)(const char* hostname, void *data,
                               struct sockaddr_in *addr);
@@ -29,7 +35,7 @@ typedef struct {
 // dns_poller_cleanup called.
 void dns_poller_init(dns_poller_t *d, struct ev_loop *loop,
                      const char *bootstrap_dns, const char *hostname,
-                     int interval_seconds, dns_poller_cb cb, void *cb_data);
+                     dns_poller_cb cb, void *cb_data);
 
 // Tears down timer and frees resources associated with a dns poller.
 void dns_poller_cleanup(dns_poller_t *d);


### PR DESCRIPTION
The current behavior is a fixed 120 second interval. On some setups,
such as OpenWrt, this leads to a long delay before DNS queries can be
serviced because the daemon may be started before the WAN interface is
operational, leading to an immediate failure of the initial bootstrap
lookup.

Depending on the host's configuration, this can cause a DNS loop, where
libcurl falls back to resolv.conf (127.0.0.1 in some setups), leading to
situations like:

         https_dns_proxy -> dnsmasq -> https_dns_proxy -> ...

         https_dns_proxy -> https_dns_proxy -> ...

Only after the 120 seconds has elapsed and the provided resolver
hostname (dns.google.com, cloudflare-dns.com, etc.) is finally resolved
would DNS begin to function.

To work around this, ares_cb() has been modified to adjust the bootstrap
interval depending on if the previous query was successful or not. If an
error or empty response is encountered, it now resets the timer with a 5
second interval (per POLLER_INTVL_ERR in dns_poller.h). Upon successful
resolution after encountering an error, the timer is re-adjusted to
POLLER_INTVL_NORMAL (120 seconds).

The initial interval that the DNS poller timer starts up with is now
POLLER_INTVL_ERR. This accounts for the possibility that the initial
bootstrap queries could dropped completely and return nothing (e.g. no
ICMP unreachable) to c-ares to trigger the callback. After
bootstrapping, the interval is set to POLLER_INTVL_NORMAL.

To avoid the potential DNS loop, dns_server_cb() now ensures that
bootstrapping has completed (if enabled) before servicing any requests.
This prevents libcurl from falling back to resolv.conf and making
queries to nameserver(s) other than those specified for bootstrap
(including those specified by the hard-coded defaults).

In testing this patch, https_dns_proxy now starts serving requests after
about 10 seconds, versus 120 seconds.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>