### PR TITLE
Use FindGTest to search for googletest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,8 @@ if(CLANG_TIDY_EXE)
   )
 endif()
 
-find_path(GTEST_HEADER gtest/gtest.h)
-if (GTEST_HEADER)
+find_package(GTest)
+if (GTEST_FOUND)
   message(STATUS "gtest found. Enabling tests.")
   enable_testing()
   


### PR DESCRIPTION
On Ubuntu 19.04, the previous way of doing things caused build errors
due to the lack of -lpthread. While explicitly adding
find_package(Threads) worked as well, this seems like a better option.

This also fixes an issue on Debian Jessie where the build would fail if
gtest.h exists but libgtest.a does not. Jessie only includes the
source files with the libgtest-dev package, and requires manually
building libgtest.a after installation.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>