### PR TITLE
Update links to point at dns.google; clarify that this is for the JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # https-dns-proxy
 
-https\_dns\_proxy is a light-weight DNS&lt;--&gt;HTTPS, non-caching translation
-proxy for the emerging [DoH](https://datatracker.ietf.org/doc/charter-ietf-doh/)
-DNS-over-HTTPS standard. It receives regular (UDP) DNS requests and issues them
-via DoH.
+`https_dns_proxy` is a light-weight DNS&lt;--&gt;HTTPS, non-caching translation
+proxy for the emerging [DoH][doh-wg] DNS-over-HTTPS standard. It receives
+regular (UDP) DNS requests and issues them via DoH (JSON).
 
-Google's [DNS-over-HTTPS](https://developers.google.com/speed/public-dns/docs/dns-over-https)
-service is default, but [Cloudflare's
-service](https://developers.cloudflare.com/1.1.1.1/dns-over-https/) also works
-with trivial commandline flag changes.
+[Google's DNS-over-HTTPS][google-json] service is default, but
+[Cloudflare's service][cloudflare-json] also works with trivial commandline flag
+changes.
+
+[cloudflare-json]: https://developers.cloudflare.com/1.1.1.1/dns-over-https/json-format/
+[doh-wg]: https://datatracker.ietf.org/wg/doh/about/
+[google-json]: https://developers.google.com/speed/public-dns/docs/doh/json
 
 ### Using Google
 
 ```bash
 # ./https_dns_proxy -u nobody -g nogroup -d -b 8.8.8.8,8.8.4.4 \
-    -r "https://dns.google.com/resolve?"
+    -r "https://dns.google/resolve?"
 ```
 
 ### Using Cloudflare
@@ -109,8 +111,8 @@ Usage: ./https_dns_proxy [-a <listen_addr>] [-p <listen_port>]
   -u user                Optional user to drop to if launched as root.
   -g group               Optional group to drop to if launched as root.
   -b dns_servers         Comma separated IPv4 address of DNS servers
-                         to resolve resolver host (e.g. dns.google.com).  (8.8.8.8,1.1.1.1,8.8.4.4,1.0.0.1,145.100.185.15,145.100.185.16,185.49.141.37)
-  -r resolver_url_prefix The HTTPS path to the JSON resolver URL.  (https://dns.google.com/resolve?)
+                         to resolve resolver host (e.g. dns.google).  (8.8.8.8,1.1.1.1,8.8.4.4,1.0.0.1,145.100.185.15,145.100.185.16,185.49.141.37)
+  -r resolver_url_prefix The HTTPS path to the JSON resolver URL.  (https://dns.google/resolve?)
   -e subnet_addr         An edns-client-subnet to use such as "203.31.0.0/16".  ()
   -t proxy_server        Optional HTTP proxy. e.g. socks5://127.0.0.1:1080
                          Remote name resolution will be used if the protocol

--- a/src/options.c
+++ b/src/options.c
@@ -26,7 +26,7 @@ void options_init(struct Options *opt) {
   opt->gid = -1;
   //new as from https://dnsprivacy.org/wiki/display/DP/DNS+Privacy+Test+Servers
   opt->bootstrap_dns = "8.8.8.8,1.1.1.1,8.8.4.4,1.0.0.1,145.100.185.15,145.100.185.16,185.49.141.37";
-  opt->resolver_url_prefix = "https://dns.google.com/resolve?";
+  opt->resolver_url_prefix = "https://dns.google/resolve?";
   opt->edns_client_subnet = "";
   opt->curl_proxy = NULL;
   opt->use_http_1_1 = 0;
@@ -136,7 +136,7 @@ void options_show_usage(int argc, char **argv) {
   printf("  -u user                Optional user to drop to if launched as root.\n");
   printf("  -g group               Optional group to drop to if launched as root.\n");
   printf("  -b dns_servers         Comma separated IPv4 address of DNS servers\n");
-  printf("                         to resolve resolver host (e.g. dns.google.com). (%s)\n",
+  printf("                         to resolve resolver host (e.g. dns.google). (%s)\n",
          defaults.bootstrap_dns);
   printf("  -r resolver_url_prefix The HTTPS path to the JSON resolver URL. (%s)\n",
          defaults.resolver_url_prefix);

--- a/src/options.h
+++ b/src/options.h
@@ -25,7 +25,7 @@ struct Options {
   uid_t uid;
   gid_t gid;
 
-  // DNS servers to look up resolver host (e.g. dns.google.com)
+  // DNS servers to look up resolver host (e.g. dns.google)
   const char *bootstrap_dns;
 
   // Resolver URL prefix to use. Must start with https://.


### PR DESCRIPTION
Reference for URL change: https://developers.google.com/speed/public-dns/docs/doh/migration#dns-google

I haven't updated the comments about "alternative protocols", but I suspect you'd like the new [RFC 8484](https://tools.ietf.org/html/rfc8484).