### PR TITLE
Source changes to avoid strict aliasing violations and uninitialised memory reads

### DIFF
--- a/src/dns_server.c
+++ b/src/dns_server.c
@@ -61,6 +61,11 @@ static void watcher_cb(struct ev_loop *loop, ev_io *w, int revents) {
     return;
   }
 
+  if (len < sizeof(uint16_t) * 3) {
+    DLOG("Malformed request received (too short).");
+    return;
+  }
+
   unsigned char *p = buf;
   uint16_t tx_id = ntohs(next_uint16(&p));
   uint16_t flags = ntohs(next_uint16(&p));

--- a/src/dns_server.c
+++ b/src/dns_server.c
@@ -40,6 +40,13 @@ static int get_listen_sock(const char *listen_addr, int listen_port) {
   return sock;
 }
 
+static uint16_t next_uint16(unsigned char **const p) {
+  uint16_t u;
+  memcpy(&u, *p, sizeof(u));
+  *p += sizeof(u);
+  return u;
+}
+
 static void watcher_cb(struct ev_loop *loop, ev_io *w, int revents) {
   dns_server_t *d = (dns_server_t *)w->data;
 
@@ -55,18 +62,15 @@ static void watcher_cb(struct ev_loop *loop, ev_io *w, int revents) {
   }
 
   unsigned char *p = buf;
-  uint16_t tx_id = ntohs(*(uint16_t *)p);
-  p += 2;
-  uint16_t flags = ntohs(*(uint16_t *)p);
-  p += 2;
-  uint16_t num_q = ntohs(*(uint16_t *)p);
-  p += 2;
-  //uint16_t num_rr = ntohs(*(uint16_t *)p);
-  p += 2;
-  //uint16_t num_arr = ntohs(*(uint16_t *)p);
-  p += 2;
-  //uint16_t num_xrr = ntohs(*(uint16_t *)p);
-  p += 2;
+  uint16_t tx_id = ntohs(next_uint16(&p));
+  uint16_t flags = ntohs(next_uint16(&p));
+  uint16_t num_q = ntohs(next_uint16(&p));
+  //uint16_t num_rr = ntohs(next_uint16(&p));
+  next_uint16(&p);
+  //uint16_t num_arr = ntohs(next_uint16(&p));
+  next_uint16(&p);
+  //uint16_t num_xrr = ntohs(next_uint16(&p));
+  next_uint16(&p);
   if (num_q != 1) {
     DLOG("Malformed request received.");
     return;
@@ -78,7 +82,7 @@ static void watcher_cb(struct ev_loop *loop, ev_io *w, int revents) {
     return;
   }
   p += enc_len;
-  uint16_t type = ntohs(*(uint16_t *)p);
+  uint16_t type = ntohs(next_uint16(&p));
 
   d->cb(d, d->cb_data, raddr, tx_id, flags, domain_name, type);
 


### PR DESCRIPTION
This changes the DNS request deserialisation code to read the `uint16`s out of the buffer without violating strict aliasing rules, which could cause crashes platforms where unaligned memory access results in a fault, or bugs where the compiler decides to take liberty with the undefined behaviour of the original code (there shouldn't be any difference in the generated assembly, as `next_uint16()` should be inlined).
