### PR TITLE
options: stop loglevel going negative

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -67,7 +67,8 @@ int options_parse_args(struct Options *opt, int argc, char **argv) {
       opt->logfile = optarg;
       break;
     case 'v': // verbose
-      opt->loglevel--;
+      if (opt->loglevel)
+	      opt->loglevel--;
       break;
     case 'x': // http/1.1
       opt->use_http_1_1 = 1;


### PR DESCRIPTION
Log level is controlled by the number of '-v' options passed in cmdline,
however there's nothing to stop the log level going negative.
Fortunately because the log level is currently a signed type the
comparison of < message level works.  Let's limit to 0.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>