### PR TITLE
IPv6 forwarder + bootstrap support

### DIFF
--- a/src/dns_poller.h
+++ b/src/dns_poller.h
@@ -12,7 +12,7 @@
 
 // Callback to be called periodically when we get a valid DNS response.
 typedef void (*dns_poller_cb)(const char* hostname, void *data,
-                              struct sockaddr_in *addr);
+                              const void *addr, const int af);
 
 typedef struct {
   ares_channel ares;

--- a/src/dns_server.h
+++ b/src/dns_server.h
@@ -8,7 +8,7 @@
 struct dns_server_s;
 
 typedef void (*dns_req_received_cb)(struct dns_server_s *dns_server, void *data,
-                                    struct sockaddr_in addr, uint16_t tx_id,
+                                    struct sockaddr addr, uint16_t tx_id,
                                     uint16_t flags, const char *name, int type);
 
 typedef struct dns_server_s {
@@ -25,7 +25,7 @@ void dns_server_init(dns_server_t *d, struct ev_loop *loop,
                      dns_req_received_cb cb, void *data);
 
 // Sends a DNS response 'buf' of length 'blen' to 'raddr'.
-void dns_server_respond(dns_server_t *d, struct sockaddr_in raddr, char *buf,
+void dns_server_respond(dns_server_t *d, struct sockaddr raddr, char *buf,
                         int blen);
 
 void dns_server_cleanup(dns_server_t *d);

--- a/src/main.c
+++ b/src/main.c
@@ -45,7 +45,7 @@ typedef struct {
 
 typedef struct {
   uint16_t tx_id;
-  struct sockaddr_in raddr;
+  struct sockaddr raddr;
   dns_server_t *dns_server;
 } request_t;
 
@@ -108,7 +108,7 @@ static void https_resp_cb(void *data, unsigned char *buf, unsigned int buflen) {
 }
 
 static void dns_server_cb(dns_server_t *dns_server, void *data,
-                          struct sockaddr_in addr, uint16_t tx_id,
+                          struct sockaddr addr, uint16_t tx_id,
                           uint16_t flags, const char *name, int type) {
   app_state_t *app = (app_state_t *)data;
 


### PR DESCRIPTION
* used `ares_ser_servers_ports`_csv provided by c-ares to parse
  bootstrap v4+v6 servers instead of manually parsing the list
* passed `AF_UNSPEC` to `ares_gethostbyname` so it grabs v4 or v6
* modified `dns_poller_cb` to pass data and address family
* modified `ares_cb` to pass addr data as `void*`, since
  `hostent->h_addr_list` are are `struct in*addr`, not `sockaddr*`