### PR TITLE
Mention gtest in build deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,11 @@ only makes sense if you trust your DoH provider.
 
 ## Build
 
-Depends on `c-ares (>=1.11.0)`, `libcurl (>=7.66.0)`, `libev (>=4.25)`.
+Depends on `c-ares (>=1.11.0)`, `libcurl (>=7.66.0)`, `libev (>=4.25)`, `gtest`.
 
 On Debian-derived systems those are libc-ares-dev,
-libcurl4-{openssl,nss,gnutls}-dev and libev-dev respectively.
-On Redhat-derived systems those are c-ares-devel, libcurl-devel and
-libev-devel.
+libcurl4-{openssl,nss,gnutls}-dev, libev-dev and libgtest-dev respectively.
+On Redhat-derived systems those are c-ares-devel, libcurl-devel, libev-devel and gtest-devel, .
 
 On MacOS, you may run into issues with curl headers. Others have had success when first installing curl with brew.
 ```


### PR DESCRIPTION
`cmake .` step is failing on unable to find GTest:
-- Could NOT find GTest (missing: GTEST_LIBRARY GTEST_INCLUDE_DIR GTEST_MAIN_LIBRARY) 

- on Fedora its package gtest-devel
- on Debian i'm just guessing based on web search that it could be libgtest-dev?