### PR TITLE
add build-essential to ubuntu instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ brew link curl --force
 
 On Ubuntu
 ```
-apt-get install cmake libc-ares-dev libcurl4-openssl-dev libev-dev
+apt-get install cmake libc-ares-dev libcurl4-openssl-dev libev-dev build-essential
 ```
 
 If all pre-requisites are met, you should be able to build with:


### PR DESCRIPTION
I was testing https_dns_proxy using a [LXD](https://linuxcontainers.org/lxd/) container and had an issue.  I was getting an error when running the `cmake .` step:

```
CMake Error at CMakeLists.txt:1 (project):
  No CMAKE_CXX_COMPILER could be found.
```

The fix was to add `build-essential` to the `apt-get install` line. Adding this should be harmless as [it installs the things needed](https://packages.ubuntu.com/bionic/build-essential) to make the software, which is what we want ;)

Here's a complete copy of my session creating a container from scratch, cloning this repo, `apt-get install`ing, getting the error, installing  `build-essential` and then not getting the error.

-------------------
```
➜  ~ lxc launch ubuntu: doh2               
Creating doh2
Starting doh2
➜  ~ lxc exec doh2 -- /bin/bash

root@doh2:~# git clone https://github.com/aarond10/https_dns_proxy.git

root@doh2:~# cd https_dns_proxy/
root@doh2:~/https_dns_proxy# apt update&&apt install -y cmake libc-ares-dev libcurl4-openssl-dev libev-dev
[SNIP]
The following additional packages will be installed:
  binutils binutils-common binutils-x86-64-linux-gnu cmake-data cpp cpp-7 gcc gcc-7 gcc-7-base gcc-8-base libarchive13 libasan4 libatomic1 libbinutils
  libc-ares2 libc-dev-bin libc6-dev libcc1-0 libcilkrts5 libev4 libgcc-7-dev libgcc1 libgomp1 libisl19 libitm1 libjsoncpp1 liblsan0 libmpc3 libmpx2
  libquadmath0 librhash0 libstdc++6 libtsan0 libubsan0 linux-libc-dev make manpages-dev
Suggested packages:
  binutils-doc cmake-doc ninja-build cpp-doc gcc-7-locales gcc-multilib autoconf automake libtool flex bison gdb gcc-doc gcc-7-multilib gcc-7-doc
  libgcc1-dbg libgomp1-dbg libitm1-dbg libatomic1-dbg libasan4-dbg liblsan0-dbg libtsan0-dbg libubsan0-dbg libcilkrts5-dbg libmpx2-dbg libquadmath0-dbg
  lrzip glibc-doc libcurl4-doc libidn11-dev libkrb5-dev libldap2-dev librtmp-dev libssh2-1-dev libssl-dev pkg-config zlib1g-dev make-doc
The following NEW packages will be installed:
  binutils binutils-common binutils-x86-64-linux-gnu cmake cmake-data cpp cpp-7 gcc gcc-7 gcc-7-base libarchive13 libasan4 libatomic1 libbinutils
  libc-ares-dev libc-ares2 libc-dev-bin libc6-dev libcc1-0 libcilkrts5 libcurl4-openssl-dev libev-dev libev4 libgcc-7-dev libgomp1 libisl19 libitm1
  libjsoncpp1 liblsan0 libmpc3 libmpx2 libquadmath0 librhash0 libtsan0 libubsan0 linux-libc-dev make manpages-dev
The following packages will be upgraded:
  gcc-8-base libgcc1 libstdc++6
3 upgraded, 38 newly installed, 0 to remove and 23 not upgraded.
Need to get 36.8 MB of archives.
After this operation, 146 MB of additional disk space will be used.
[SNIP]
root@doh2:~/https_dns_proxy# cmake .
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is unknown
CMake Error at CMakeLists.txt:1 (project):
  No CMAKE_CXX_COMPILER could be found.

root@doh2:~/https_dns_proxy# apt install -y build-essential
Reading package lists... Done
Building dependency tree       
Reading state information... Done

The following additional packages will be installed:
  dpkg-dev fakeroot g++ g++-7 libalgorithm-diff-perl libalgorithm-diff-xs-perl libalgorithm-merge-perl libdpkg-perl libfakeroot libfile-fcntllock-perl
  libstdc++-7-dev
Suggested packages:
  debian-keyring g++-multilib g++-7-multilib gcc-7-doc libstdc++6-7-dbg bzr libstdc++-7-doc
The following NEW packages will be installed:
  build-essential dpkg-dev fakeroot g++ g++-7 libalgorithm-diff-perl libalgorithm-diff-xs-perl libalgorithm-merge-perl libdpkg-perl libfakeroot
  libfile-fcntllock-perl libstdc++-7-dev
0 upgraded, 12 newly installed, 0 to remove and 23 not upgraded.
Need to get 12.2 MB of archives.


root@doh2:~/https_dns_proxy# cmake .
-- The CXX compiler identification is GNU 7.5.0
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- clang-tidy not found.
-- Could NOT find GTest (missing: GTEST_LIBRARY GTEST_INCLUDE_DIR GTEST_MAIN_LIBRARY) 
-- Configuring done
-- Generating done
-- Build files have been written to: /root/https_dns_proxy
```