### PR TITLE
Add -c DSCP codepoint option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Usage: ./https_dns_proxy [-a <listen_addr>] [-p <listen_port>]
                          supports it (http, https, socks4a, socks5h), otherwise
                          initial DNS resolution will still be done via the
                          bootstrap DNS servers.
+  -c dscp_codepoint      Optional DSCP codepoint[0-63] to set on upstream DNS server
+                         connections.
   -l logfile             Path to file to log to. ("-")
   -x                     Use HTTP/1.1 instead of HTTP/2. Useful with broken
                          or limited builds of libcurl. (false)

--- a/src/https_client.c
+++ b/src/https_client.c
@@ -7,6 +7,7 @@
 #include <grp.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/ip.h>
 #include <pwd.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -34,6 +35,30 @@ static size_t write_buffer(void *buf, size_t size, size_t nmemb, void *userp) {
   ctx->buf[ctx->buflen] = '\0';
   return size * nmemb;
 }
+
+#if defined(IP_TOS)
+static curl_socket_t opensocket_callback(void *clientp, curlsocktype purpose, struct curl_sockaddr *addr) {
+  curl_socket_t sock;
+
+  sock=socket(addr->family, addr->socktype, addr->protocol);
+
+  if (purpose != CURLSOCKTYPE_IPCXN)
+	return sock;
+
+  if (sock != -1) {
+	if (addr->family == AF_INET) {
+		(void)setsockopt(sock, IPPROTO_IP, IP_TOS, (int *)clientp, sizeof(int));
+	}
+#if defined(IPV6_TCLASS)
+	else if (addr->family == AF_INET6) {
+		(void)setsockopt(sock, IPPROTO_IPV6, IPV6_TCLASS, (int *)clientp, sizeof(int));
+	}
+#endif
+  }
+
+  return sock;
+}
+#endif
 
 static void https_fetch_ctx_init(https_client_t *client,
                                  struct https_fetch_ctx *ctx, const char *url,
@@ -63,6 +88,12 @@ static void https_fetch_ctx_init(https_client_t *client,
   if (logging_debug_enabled()) {
     curl_easy_setopt(ctx->curl, CURLOPT_VERBOSE, 1L);
   }
+#if defined(IP_TOS)
+  if (client->opt->dscp) {
+	  curl_easy_setopt(ctx->curl, CURLOPT_OPENSOCKETDATA, &client->opt->dscp);
+	  curl_easy_setopt(ctx->curl, CURLOPT_OPENSOCKETFUNCTION, opensocket_callback);
+  }
+#endif
   curl_easy_setopt(ctx->curl, CURLOPT_URL, url);
   ctx->header_list = curl_slist_append(ctx->header_list, "Accept: application/dns-message");
   ctx->header_list = curl_slist_append(ctx->header_list, "Content-Type: application/dns-message");

--- a/src/options.c
+++ b/src/options.c
@@ -25,6 +25,7 @@ void options_init(struct Options *opt) {
   opt->logfd = -1;
   opt->loglevel = LOG_ERROR;
   opt->daemonize = 0;
+  opt->dscp = 0;
   opt->user = NULL;
   opt->group = NULL;
   opt->uid = -1;
@@ -39,10 +40,13 @@ void options_init(struct Options *opt) {
 
 int options_parse_args(struct Options *opt, int argc, char **argv) {
   int c;
-  while ((c = getopt(argc, argv, "a:p:du:g:b:4r:e:t:l:vx")) != -1) {
+  while ((c = getopt(argc, argv, "a:c:p:du:g:b:4r:e:t:l:vx")) != -1) {
     switch (c) {
     case 'a': // listen_addr
       opt->listen_addr = optarg;
+      break;
+    case 'c': // DSCP codepoint
+      opt->dscp = atoi(optarg);
       break;
     case 'p': // listen_port
       opt->listen_port = atoi(optarg);
@@ -103,6 +107,11 @@ int options_parse_args(struct Options *opt, int argc, char **argv) {
     }
     opt->gid = g->gr_gid;
   }
+  if (opt->dscp < 0 || opt->dscp >63) {
+      printf("DSCP code (%d) invalid:[0-63]\n", opt->dscp);
+      return -1;
+  }
+  opt->dscp <<= 2;
   // Get noisy about bad security practices.
   if (getuid() == 0 && (!opt->user || !opt->group)) {
     printf("----------------------------\n"
@@ -134,7 +143,8 @@ void options_show_usage(int argc, char **argv) {
   printf("Usage: %s [-a <listen_addr>] [-p <listen_port>]\n", argv[0]);
   printf("        [-d] [-u <user>] [-g <group>] [-b <dns_servers>]\n");
   printf("        [-r <resolver_url>] [-e <subnet_addr>]\n");
-  printf("        [-t <proxy_server>] [-l <logfile>] [-x] [-v]+\n\n");
+  printf("        [-t <proxy_server>] [-l <logfile>] -c <dscp_codepoint>\n");
+  printf("        [-x] [-v]+\n\n");
   printf("  -a listen_addr         Local IPv4/v6 address to bind to. (%s)\n",
          defaults.listen_addr);
   printf("  -p listen_port         Local port to bind to. (%d)\n",
@@ -157,6 +167,8 @@ void options_show_usage(int argc, char **argv) {
   printf("                         bootstrap DNS servers.\n");
   printf("  -l logfile             Path to file to log to. (\"%s\")\n",
          defaults.logfile);
+  printf("  -c dscp_codepoint      Optional DSCP codepoint[0-63] to set on upstream DNS server\n");
+  printf("                         connections.\n");
   printf("  -x                     Use HTTP/1.1 instead of HTTP/2. Useful with broken\n"
          "                         or limited builds of libcurl. (false)\n");
   printf("  -v                     Increase logging verbosity. (INFO)\n");

--- a/src/options.h
+++ b/src/options.h
@@ -30,6 +30,8 @@ struct Options {
 
   int ipv4;  // if non-zero, will only use AF_INET addresses.
 
+  int dscp; // mark packet with DSCP
+
   // Resolver URL prefix to use. Must start with https://.
   const char *resolver_url;
 


### PR DESCRIPTION
Specify a DSCP codepoint on DNS server upstream connections.  This may
be useful to those using qdiscs/AQMs that categorise traffic
importance/priority by DSCP value.

Whilst this could be done by ip/nftables rules, let's get the
application to do it.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>