### PR TITLE
Update documentation to reference Docker install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ There is also an externally maintained [AUR package](https://aur.archlinux.org/p
 user@arch:~# yaourt -S https-dns-proxy-git
 ```
 
+### Docker install
+
+There is also an externally maintained [Docker image](https://hub.docker.com/repository/docker/bwmoran/https-dns-proxy/general) for latest git version. Documentation, Dockerfile, and entrypoint script can be viewed on [GitHub](https://github.com/moranbw/https-dns-proxy-docker).  An example run:
+
+```
+### points towards AdGuard DNS, only use IPv4, increase logging ###
+
+docker run --name "https-dns-proxy" -p 5053:5053/udp  \
+  -e DNS_SERVERS="94.140.14.14,94.140.15.15" \
+  -e RESOLVER_URL="https://dns.adguard.com/dns-query" \
+  -d bwmoran/https-dns-proxy \
+  -4 -vvv
+```
+
 ## Usage
 
 Just run it as a daemon and point traffic at it. Commandline flags are:


### PR DESCRIPTION
I created a pretty basic Dockerfile that pulls from your repo and builds.  I expose value-based flags as environment variables (i.e. DNS_SERVERS) and pure flags as cmd arguments (i.e. -4).

Perhaps running in a container is a fringe use case, but it seems to work well.

https://github.com/moranbw/https-dns-proxy-docker