### PR TITLE
Fix segmentation fault by adding missing <string.h>

### DIFF
--- a/src/dns_poller.c
+++ b/src/dns_poller.c
@@ -1,5 +1,6 @@
 #include <math.h>        // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <netdb.h>       // NOLINT(llvmlibc-restrict-system-libc-headers)
+#include <string.h>      // NOLINT(llvmlibc-restrict-system-libc-headers)
 
 #include "dns_poller.h"
 #include "logging.h"

--- a/src/dns_server.c
+++ b/src/dns_server.c
@@ -3,6 +3,7 @@
 #include <errno.h>          // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <netdb.h>          // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <netinet/in.h>     // NOLINT(llvmlibc-restrict-system-libc-headers)
+#include <string.h>         // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <sys/socket.h>     // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <unistd.h>         // NOLINT(llvmlibc-restrict-system-libc-headers)
 

--- a/src/https_client.c
+++ b/src/https_client.c
@@ -2,6 +2,7 @@
 #include <ev.h>            // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <math.h>          // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <netinet/in.h>    // NOLINT(llvmlibc-restrict-system-libc-headers)
+#include <string.h>        // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <sys/socket.h>    // NOLINT(llvmlibc-restrict-system-libc-headers)
 
 #include "https_client.h"

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include <errno.h>         // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <grp.h>           // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <pwd.h>           // NOLINT(llvmlibc-restrict-system-libc-headers)
+#include <string.h>        // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <sys/types.h>     // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <unistd.h>        // NOLINT(llvmlibc-restrict-system-libc-headers)
 
@@ -159,7 +160,7 @@ static void dns_poll_cb(const char* hostname, void *data,
   curl_slist_free_all(app->resolv);
   app->resolv = curl_slist_append(NULL, buf);
   // Resets curl or it gets in a mess due to IP of streaming connection not
-  // matching that of configured DNS. 
+  // matching that of configured DNS.
   https_client_reset(app->https_client);
 }
 

--- a/src/options.c
+++ b/src/options.c
@@ -2,6 +2,7 @@
 #include <grp.h>           // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <pwd.h>           // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <stdio.h>         // NOLINT(llvmlibc-restrict-system-libc-headers)
+#include <string.h>        // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <sys/stat.h>      // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <sys/types.h>     // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <unistd.h>        // NOLINT(llvmlibc-restrict-system-libc-headers)
@@ -127,7 +128,7 @@ int options_parse_args(struct Options *opt, int argc, char **argv) {
   if (opt->logfile == NULL ||
       !strcmp(opt->logfile, "-")) {
     opt->logfd = STDOUT_FILENO;
-  } else if ((opt->logfd = open(opt->logfile, 
+  } else if ((opt->logfd = open(opt->logfile,
                                 O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC,
                                 S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP)) <= 0) {
     printf("Logfile '%s' is not writable.\n", opt->logfile);


### PR DESCRIPTION
Hi, I found the `strerror()` cannot work properly to return the information corresponded to the errno value (segmentation fault).

Therefore, I add the `<string.h>` header for solving the build warning and the more important thing is to fix the segmentation fault as `stderror`'s result requires `string.h` included.

Ref:
https://stackoverflow.com/questions/17174081/why-cant-the-result-of-strerror-be-returned
https://stackoverflow.com/questions/47112630/segmentation-fault-when-print-errno-for-shm-open-in-linux
