### PR TITLE
Prevent error log flood if HTTP/2 is unsupported

### DIFF
--- a/src/https_client.c
+++ b/src/https_client.c
@@ -101,7 +101,8 @@ static void https_fetch_ctx_init(https_client_t *client,
   if (easy_code != CURLE_OK) {
     ELOG("CURLOPT_HTTP_VERSION error %d: %s", easy_code, curl_easy_strerror(easy_code));
     if (!client->opt->use_http_1_1) {
-      ELOG("Try to run application with -x argument!");
+      ELOG("Try to run application with -x argument! Forcing HTTP/1.1 version.");
+      client->opt->use_http_1_1 = 1;
     }
   }
 


### PR DESCRIPTION
If HTTP/2 is unsupported by libcurl, force HTTP/1.1
This will prevent log flood, by printing log only in case of first request.

Tested by changing CURL_HTTP_VERSION_2_0 to invalid randum number
and sending in multiple requests at the same time, so new HTTP
session open would be needed.

Fix for: #115 