### PR TITLE
Request debug logging improvement

### DIFF
--- a/src/dns_poller.c
+++ b/src/dns_poller.c
@@ -176,6 +176,9 @@ void dns_poller_init(dns_poller_t *d, struct ev_loop *loop,
   }
   DLOG("Nameservers count: %d", nameservers);
   d->io_events = (ev_io *)calloc(nameservers, sizeof(ev_io));  // zeroed!
+  if (!d->io_events) {
+    FLOG("Out of mem");
+  }
   for (int i = 0; i < nameservers; i++) {
     d->io_events[i].data = d;
   }

--- a/src/dns_server.c
+++ b/src/dns_server.c
@@ -68,19 +68,16 @@ static void watcher_cb(struct ev_loop __attribute__((unused)) *loop,
   int len = recvfrom(w->fd, buf, REQUEST_MAX, 0, (struct sockaddr*)&raddr,
                      &tmp_addrlen);
   if (len < 0) {
-    WLOG("recvfrom failed: %s", strerror(errno));
+    ELOG("recvfrom failed: %s", strerror(errno));
     return;
   }
 
   if (len < (int)sizeof(uint16_t)) {
-    DLOG("Malformed request received (too short).");
+    WLOG("Malformed request received (too short).");
     return;
   }
 
-  uint16_t net_tx_id = 0;
-  // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
-  memcpy(&net_tx_id, buf, sizeof(net_tx_id));
-  uint16_t tx_id = ntohs(net_tx_id);
+  uint16_t tx_id = ntohs(*((uint16_t*)buf));
   d->cb(d, d->cb_data, (struct sockaddr*)&raddr, tx_id, buf, len);
 }
 

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -15,6 +15,8 @@ typedef void (*https_response_cb)(void *data, char *buf, size_t buflen);
 struct https_fetch_ctx {
   CURL *curl;
 
+  uint16_t id;
+
   https_response_cb cb;
   void *cb_data;
 
@@ -44,8 +46,8 @@ void https_client_init(https_client_t *c, options_t *opt,
 
 void https_client_fetch(https_client_t *c, const char *url,
                         const char* postdata, size_t postdata_len,
-                        struct curl_slist *resolv, https_response_cb cb,
-                        void *data);
+                        struct curl_slist *resolv, uint16_t id,
+                        https_response_cb cb, void *data);
 
 // Used to reset state of libcurl because streaming connections + IP changes
 // seem to cause curl to flip out.

--- a/src/logging.h
+++ b/src/logging.h
@@ -27,7 +27,7 @@ void _log(const char *file, int line, int severity, const char *fmt, ...);
 }
 #endif
 
-enum _LogSeverity {
+enum LogSeverity {
   LOG_DEBUG,
   LOG_INFO,
   LOG_WARNING,
@@ -37,6 +37,7 @@ enum _LogSeverity {
   LOG_MAX
 };
 
+#define LOG(level, ...) _log(__FILENAME__, __LINE__, level, __VA_ARGS__)
 #define DLOG(...) _log(__FILENAME__, __LINE__, LOG_DEBUG, __VA_ARGS__)
 #define ILOG(...) _log(__FILENAME__, __LINE__, LOG_INFO, __VA_ARGS__)
 #define WLOG(...) _log(__FILENAME__, __LINE__, LOG_WARNING, __VA_ARGS__)

--- a/src/main.c
+++ b/src/main.c
@@ -78,17 +78,27 @@ static void sigpipe_cb(struct ev_loop __attribute__((__unused__)) *loop,
 }
 
 static void https_resp_cb(void *data, char *buf, size_t buflen) {
-  DLOG("buflen %u\n", buflen);
   request_t *req = (request_t *)data;
+  DLOG("Received response for id: %hX, len: %zu", req->tx_id, buflen);
   if (req == NULL) {
-    FLOG("data NULL");
+    FLOG("%04hX: data NULL", req->tx_id);
   }
   free((void*)req->dns_req);
   if (buf != NULL) { // May be NULL for timeout, DNS failure, or something similar.
-    dns_server_respond(req->dns_server, (struct sockaddr*)&req->raddr, buf, buflen);
-  }
-  if (req->stat) {
-    stat_request_end(req->stat, buflen, ev_now(req->dns_server->loop) - req->start_tstamp);
+    if (buflen < (int)sizeof(uint16_t)) {
+      WLOG("%04hX: Malformed response received (too short)", req->tx_id);
+    } else {
+      uint16_t response_id = ntohs(*((uint16_t*)buf));
+      if (req->tx_id != response_id) {
+        WLOG("DNS request and response IDs are not matching: %hX != %hX",
+             req->tx_id, response_id);
+      } else {
+        dns_server_respond(req->dns_server, (struct sockaddr*)&req->raddr, buf, buflen);
+        if (req->stat) {
+          stat_request_end(req->stat, buflen, ev_now(req->dns_server->loop) - req->start_tstamp);
+        }
+      }
+    }
   }
   free(req);
 }
@@ -98,20 +108,20 @@ static void dns_server_cb(dns_server_t *dns_server, void *data,
                           char *dns_req, size_t dns_req_len) {
   app_state_t *app = (app_state_t *)data;
 
-  DLOG("Received request for id: %04x, len: %d", tx_id, dns_req_len);
+  DLOG("Received request for id: %hX, len: %d", tx_id, dns_req_len);
 
   // If we're not yet bootstrapped, don't answer. libcurl will fall back to
   // gethostbyname() which can cause a DNS loop due to the nameserver listed
   // in resolv.conf being or depending on https_dns_proxy itself.
   if(app->using_dns_poller && (app->resolv == NULL || app->resolv->data == NULL)) {
-    WLOG("Query received before bootstrapping is completed, discarding.");
+    WLOG("%04hX: Query received before bootstrapping is completed, discarding.", tx_id);
     free(dns_req);
     return;
   }
 
   request_t *req = (request_t *)calloc(1, sizeof(request_t));
   if (req == NULL) {
-    FLOG("Out of mem");
+    FLOG("%04hX: Out of mem", tx_id);
   }
   req->tx_id = tx_id;
   memcpy(&req->raddr, addr, dns_server->addrlen);  // NOLINT(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
@@ -124,7 +134,7 @@ static void dns_server_cb(dns_server_t *dns_server, void *data,
     stat_request_begin(app->stat, dns_req_len);
   }
   https_client_fetch(app->https_client, app->resolver_url,
-                     dns_req, dns_req_len, app->resolv, https_resp_cb, req);
+                     dns_req, dns_req_len, app->resolv, req->tx_id, https_resp_cb, req);
 }
 
 static int addr_list_reduced(const char* full_list, const char* list) {

--- a/src/stat.h
+++ b/src/stat.h
@@ -1,3 +1,15 @@
+// Statistics tracking
+//
+// Connection, request and latency statistics are accumulated in a struct
+// and output periodically via a libev timer callback.
+//
+// stat_init() initializes this struct and starts the timer if required.
+// stat_stop() stops the timer for shutdown.
+// stat_cleanup() prints the final measurement.
+// stat_request_(begin|end) and
+// stat_connection_(open|closed|reused) update the tallies.
+//
+
 #ifndef _STAT_H_
 #define _STAT_H_
 


### PR DESCRIPTION
Hi,
For now this is my last pack of changes.
Even I hope, that there won't be any more huge patches from me :D
Now seriously:

- I have created a function to proxy curl debug info, so it could be logged with own logging macros.
- DNS request ID is printed at the beginning of every line, so if multiple requests are processed at the time it's easier to distinguish them.

Br,
Balázs