### PR TITLE
Fixes and improvements 6

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
+    - name: Update APT
+      run: sudo apt-get update
+
     - name: Setup Dependencies
       run: sudo apt-get install cmake libc-ares-dev libcurl4-openssl-dev libev-dev build-essential clang clang-tidy
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(HttpsDnsProxy)
+project(HttpsDnsProxy C)
 cmake_minimum_required(VERSION 2.8)
 
 # source: https://stackoverflow.com/a/27990434

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(HttpsDnsProxy C)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.7)
 
 # source: https://stackoverflow.com/a/27990434
 function(define_file_basename_for_sources targetname)
@@ -15,9 +15,14 @@ endfunction()
 set(CMAKE_BUILD_TYPE "Debug")
 #set(CMAKE_BUILD_TYPE "Release")
 
-#set(CMAKE_C_FLAGS "-Wall -Wextra --pedantic -Wno-strict-aliasing")
+set(CMAKE_C_FLAGS "-Wall -Wextra --pedantic -Wno-strict-aliasing -Wno-variadic-macros")
 set(CMAKE_C_FLAGS_DEBUG "-g -DDEBUG")
 set(CMAKE_C_FLAGS_RELEASE "-O2")
+
+if ((CMAKE_C_COMPILER_ID MATCHES GNU   AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9) OR
+    (CMAKE_C_COMPILER_ID MATCHES Clang AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 10))
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-gnu-zero-variadic-macro-arguments -Wno-gnu-folding-constant")
+endif()
 
 find_package(Git)
 if(Git_FOUND)
@@ -53,7 +58,7 @@ if(NOT CLANG_TIDY_EXE)
   message(STATUS "clang-tidy not found.")
 else()
   message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-  set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-fix" "-checks=*,-clang-analyzer-alpha.*,-misc-unused-parameters,-cert-err34-c,-google-readability-todo,-hicpp-signed-bitwise,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers")
+  set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-fix" "-checks=*,-clang-analyzer-alpha.*,-misc-unused-parameters,-cert-err34-c,-google-readability-todo,-hicpp-signed-bitwise,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-gnu-folding-constant,-gnu-zero-variadic-macro-arguments")
 endif()
 
 # The main binary

--- a/munin/https_dns_proxy.plugin
+++ b/munin/https_dns_proxy.plugin
@@ -46,24 +46,26 @@ pattern='stat\.c:[0-9]+ ([0-9]+) ([0-9]+) ([0-9]+) ([0-9]+) ([0-9]+) ([0-9]+) ([
 IFS='
 '
 for line in $log_lines; do
-  if [[ ! $line =~ $pattern ]]; then
-    echo "stat regexp did not match with line: $line" >&2
+  if [[ $line =~ $pattern ]]; then
+    stat=("${BASH_REMATCH[@]}")
+  # else
+  #   echo "stat regexp did not match with line: $line" >&2
   fi
 done
 
 latency='U'
-if [ -n ${BASH_REMATCH[3]} ] && \
-   [ -n ${BASH_REMATCH[2]} ] && \
-   [ ${BASH_REMATCH[2]} -gt 0 ]; then
-  latency=$((${BASH_REMATCH[3]} / ${BASH_REMATCH[2]}))
+if [ -n "${stat[3]}" ] && \
+   [ -n "${stat[2]}" ] && \
+   [ "${stat[2]}" -gt "0" ]; then
+  latency=$((${stat[3]} / ${stat[2]}))
 fi
 
 echo "multigraph https_dns_proxy_count"
-echo "requests.value ${BASH_REMATCH[1]:-U}"
-echo "responses.value ${BASH_REMATCH[2]:-U}"
+echo "requests.value ${stat[1]:-U}"
+echo "responses.value ${stat[2]:-U}"
 echo "multigraph https_dns_proxy_latency"
 echo "latency.value ${latency}"
 echo "multigraph https_dns_proxy_connections"
-echo "opened.value ${BASH_REMATCH[6]:-U}"
-echo "closed.value ${BASH_REMATCH[7]:-U}"
-echo "reused.value ${BASH_REMATCH[8]:-U}"
+echo "opened.value ${stat[6]:-U}"
+echo "closed.value ${stat[7]:-U}"
+echo "reused.value ${stat[8]:-U}"

--- a/src/https_client.c
+++ b/src/https_client.c
@@ -25,7 +25,7 @@
 
 #define ASSERT_CURL_MULTI_SETOPT(curlm, option, param) \
   do { \
-    CURLMcode code = curl_multi_setopt(curlm, option, param); \
+    CURLMcode code = curl_multi_setopt((curlm), (option), (param)); \
     if (code != CURLM_OK) { \
       FLOG(#option " error %d: %s", code, curl_multi_strerror(code)); \
     } \
@@ -33,7 +33,7 @@
 
 #define ASSERT_CURL_EASY_SETOPT(ctx, option, param) \
   do { \
-    CURLcode code = curl_easy_setopt(ctx->curl, option, param); \
+    CURLcode code = curl_easy_setopt((ctx)->curl, (option), (param)); \
     if (code != CURLE_OK) { \
       FLOG_REQ(#option " error %d: %s", code, curl_easy_strerror(code)); \
     } \
@@ -117,16 +117,21 @@ static void https_log_data(enum LogSeverity level, struct https_fetch_ctx *ctx,
     char str[width + 1];
     size_t hex_off = 0;
     size_t str_off = 0;
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
     memset(hex, 0, sizeof(hex));
+    // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
     memset(str, 0, sizeof(str));
 
     for (size_t c = 0; c < width; c++) {
       if (i+c < size) {
+        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
         hex_off += snprintf(hex + hex_off, sizeof(hex) - hex_off,
                             "%02x ", (unsigned char)ptr[i+c]);
+        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
         str_off += snprintf(str + str_off, sizeof(str) - str_off,
                             "%c", isprint(ptr[i+c]) ? ptr[i+c] : '.');
       } else {
+        // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling)
         hex_off += snprintf(hex + hex_off, sizeof(hex) - hex_off, "   ");
       }
     }
@@ -572,7 +577,7 @@ void https_client_fetch(https_client_t *c, const char *url,
   struct https_fetch_ctx *ctx =
       (struct https_fetch_ctx *)calloc(1, sizeof(struct https_fetch_ctx));
   if (!ctx) {
-    FLOG_REQ("Out of mem");
+    FLOG("Out of mem");
   }
   https_fetch_ctx_init(c, ctx, url, postdata, postdata_len, resolv, id, cb, data);
 }

--- a/src/https_client.c
+++ b/src/https_client.c
@@ -147,7 +147,7 @@ static void https_log_data(enum LogSeverity level, struct https_fetch_ctx *ctx,
 }
 
 static
-int https_curl_debug(CURL * __attribute__((unused)) handle, curl_infotype type,
+int https_curl_debug(CURL __attribute__((unused)) * handle, curl_infotype type,
                      char *data, size_t size, void *userp)
 {
   GET_PTR(struct https_fetch_ctx, ctx, userp);
@@ -308,7 +308,7 @@ static int https_fetch_ctx_process_response(https_client_t *client,
       }
     } else {
       ELOG_REQ("curl response code: %d, content length: %zu", long_resp, ctx->buflen);
-      if (ctx->buflen >= 0) {
+      if (ctx->buflen > 0) {
         https_log_data(LOG_ERROR, ctx, ctx->buf, ctx->buflen);
       }
     }

--- a/src/logging.h
+++ b/src/logging.h
@@ -43,6 +43,9 @@ enum LogSeverity {
 #define WLOG(...) _log(__FILENAME__, __LINE__, LOG_WARNING, __VA_ARGS__)
 #define ELOG(...) _log(__FILENAME__, __LINE__, LOG_ERROR, __VA_ARGS__)
 #define SLOG(...) _log(__FILENAME__, __LINE__, LOG_STATS, __VA_ARGS__)
-#define FLOG(...) _log(__FILENAME__, __LINE__, LOG_FATAL, __VA_ARGS__)
+#define FLOG(...) do { \
+  _log(__FILE__, __LINE__, LOG_FATAL, __VA_ARGS__); \
+  exit(1); /* for clang-tidy! */ \
+} while(0)
 
 #endif // _LOGGING_H_

--- a/src/options.c
+++ b/src/options.c
@@ -39,7 +39,7 @@ void options_init(struct Options *opt) {
 
 int options_parse_args(struct Options *opt, int argc, char **argv) {
   int c = 0;
-  while ((c = getopt(argc, argv, "a:c:p:du:g:b:i:4r:e:t:l:vxs:V")) != -1) {
+  while ((c = getopt(argc, argv, "a:c:p:du:g:b:i:4r:e:t:l:vxs:hV")) != -1) {
     switch (c) {
     case 'a': // listen_addr
       opt->listen_addr = optarg;
@@ -85,15 +85,17 @@ int options_parse_args(struct Options *opt, int argc, char **argv) {
     case 'x': // http/1.1
       opt->use_http_1_1 = 1;
       break;
-    case 'V': // version
-      printf("%s\n", GIT_VERSION);
-      exit(0);
     case 's': // stats interval
       opt->stats_interval = atoi(optarg);
       break;
     case '?':
       printf("Unknown option '-%c'\n", c);
+      // fallthrough
+    case 'h':
       return -1;
+    case 'V': // version
+      printf("%s\n", GIT_VERSION);
+      exit(0);
     default:
       printf("Unknown state!");
       exit(EXIT_FAILURE);
@@ -159,9 +161,9 @@ void options_show_usage(int __attribute__((unused)) argc, char **argv) {
   options_init(&defaults);
   printf("Usage: %s [-a <listen_addr>] [-p <listen_port>]\n", argv[0]);
   printf("        [-d] [-u <user>] [-g <group>] [-b <dns_servers>]\n");
-  printf("        [-r <resolver_url>] [-e <subnet_addr>]\n");
-  printf("        [-t <proxy_server>] [-l <logfile>] -c <dscp_codepoint>\n");
-  printf("        [-x] [-v]+\n\n");
+  printf("        [-i <polling_interval>] [-4] [-r <resolver_url>]\n");
+  printf("        [-t <proxy_server>] [-l <logfile>] [-c <dscp_codepoint>]\n");
+  printf("        [-x] [-q] [-s <statistic_interval>] [-v]+ [-V] [-h]\n\n");
   printf("  -a listen_addr         Local IPv4/v6 address to bind to. (%s)\n",
          defaults.listen_addr);
   printf("  -p listen_port         Local port to bind to. (%d)\n",
@@ -196,6 +198,7 @@ void options_show_usage(int __attribute__((unused)) argc, char **argv) {
          defaults.stats_interval);
   printf("  -v                     Increase logging verbosity. (INFO)\n");
   printf("  -V                     Print version and exit.\n");
+  printf("  -h                     Print help and exit.\n");
   options_cleanup(&defaults);
 }
 


### PR DESCRIPTION
Hi,
here we go again:

1. To skip C++ compiler check by cmake the project language is set to only C
2. clang-tidy finding fixes
3. Fixed munin plugin, because in case of internet outage (BASH_REMATCH variable was cleared by error logs and) graph was not made
4. Using macro to cast and check pointer in https_client.c (I don't like macros, but it's less line this way...)
5. Fixed --help a bit
6. Because of #123 a new error message was added to help clients with debugging if DNS resolving does not work

As always: I have tested my changes in my own server.

I hope, you will like it.
Sincerely,
Balázs