### PR TITLE
Fixes 7

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,10 +1,6 @@
 name: CMake
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -12,20 +8,23 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        compiler: [gcc, clang]
+        compiler: [gcc-10, clang-12]
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Update APT
       run: sudo apt-get update
 
     - name: Setup Dependencies
-      run: sudo apt-get install cmake libc-ares-dev libcurl4-openssl-dev libev-dev build-essential clang clang-tidy
+      run: sudo apt-get install cmake libc-ares-dev libcurl4-openssl-dev libev-dev build-essential clang-tidy-12 ${{ matrix.compiler }}
+
+    - name: Set clang-tidy
+      run: sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12 100
 
     - name: Configure CMake
       env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if(NOT CLANG_TIDY_EXE)
   message(STATUS "clang-tidy not found.")
 else()
   message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-  set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-fix" "-checks=*,-clang-analyzer-alpha.*,-misc-unused-parameters,-cert-err34-c,-google-readability-todo,-hicpp-signed-bitwise,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-gnu-folding-constant,-gnu-zero-variadic-macro-arguments")
+  set(DO_CLANG_TIDY "${CLANG_TIDY_EXE}" "-fix" "-checks=*,-clang-analyzer-alpha.*,-misc-unused-parameters,-cert-err34-c,-google-readability-todo,-hicpp-signed-bitwise,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-gnu-folding-constant,-gnu-zero-variadic-macro-arguments,-readability-function-cognitive-complexity,-concurrency-mt-unsafe")
 endif()
 
 # The main binary

--- a/src/dns_poller.c
+++ b/src/dns_poller.c
@@ -97,6 +97,7 @@ static ev_tstamp get_timeout(dns_poller_t *d)
     static struct timeval max_tv = {.tv_sec = 5, .tv_usec = 0};
     struct timeval tv;
     struct timeval *tvp = ares_timeout(d->ares, &max_tv, &tv);
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     ev_tstamp after = tvp->tv_sec + tvp->tv_usec * 1e-6;
     return after ? after : 0.1;
 }

--- a/src/dns_server.c
+++ b/src/dns_server.c
@@ -65,8 +65,8 @@ static void watcher_cb(struct ev_loop __attribute__((unused)) *loop,
   struct sockaddr_storage raddr;
   /* recvfrom can write to addrlen */
   socklen_t tmp_addrlen = d->addrlen;
-  int len = recvfrom(w->fd, buf, REQUEST_MAX, 0, (struct sockaddr*)&raddr,
-                     &tmp_addrlen);
+  ssize_t len = recvfrom(w->fd, buf, REQUEST_MAX, 0, (struct sockaddr*)&raddr,
+                         &tmp_addrlen);
   if (len < 0) {
     ELOG("recvfrom failed: %s", strerror(errno));
     return;
@@ -96,7 +96,7 @@ void dns_server_init(dns_server_t *d, struct ev_loop *loop,
 }
 
 void dns_server_respond(dns_server_t *d, struct sockaddr *raddr, char *buf,
-                        int blen) {
+                        size_t blen) {
   ssize_t len = sendto(d->sock, buf, blen, 0, raddr, d->addrlen);
   if(len == -1) {
     DLOG("sendto failed: %s", strerror(errno));

--- a/src/dns_server.h
+++ b/src/dns_server.h
@@ -26,7 +26,7 @@ void dns_server_init(dns_server_t *d, struct ev_loop *loop,
 
 // Sends a DNS response 'buf' of length 'blen' to 'raddr'.
 void dns_server_respond(dns_server_t *d, struct sockaddr *raddr, char *buf,
-                        int blen);
+                        size_t blen);
 
 void dns_server_stop(dns_server_t *d);
 

--- a/src/https_client.c
+++ b/src/https_client.c
@@ -6,7 +6,7 @@
 #include <stdio.h>         // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <string.h>        // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <sys/socket.h>    // NOLINT(llvmlibc-restrict-system-libc-headers)
-#include <unistd.h>
+#include <unistd.h>        // NOLINT(llvmlibc-restrict-system-libc-headers)
 
 #include "https_client.h"
 #include "logging.h"

--- a/src/https_client.c
+++ b/src/https_client.c
@@ -605,10 +605,7 @@ void https_client_init(https_client_t *c, options_t *opt,
   c->opt = opt;
   c->stat = stat;
 
-  ASSERT_CURL_MULTI_SETOPT(c->curlm, CURLMOPT_PIPELINING,
-                           c->opt->use_http_1_1 ?
-                           CURLPIPE_HTTP1 :
-                           CURLPIPE_MULTIPLEX);
+  ASSERT_CURL_MULTI_SETOPT(c->curlm, CURLMOPT_PIPELINING, CURLPIPE_HTTP1 | CURLPIPE_MULTIPLEX);
   ASSERT_CURL_MULTI_SETOPT(c->curlm, CURLMOPT_MAX_TOTAL_CONNECTIONS, MAX_TOTAL_CONNECTIONS);
   ASSERT_CURL_MULTI_SETOPT(c->curlm, CURLMOPT_SOCKETDATA, c);
   ASSERT_CURL_MULTI_SETOPT(c->curlm, CURLMOPT_SOCKETFUNCTION, multi_sock_cb);

--- a/src/https_client.c
+++ b/src/https_client.c
@@ -273,6 +273,7 @@ static void https_fetch_ctx_init(https_client_t *client,
   ASSERT_CURL_EASY_SETOPT(ctx, CURLOPT_TIMEOUT, 10 /* seconds */);
   // We know Google supports this, so force it.
   ASSERT_CURL_EASY_SETOPT(ctx, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+  ASSERT_CURL_EASY_SETOPT(ctx, CURLOPT_ERRORBUFFER, ctx->curl_errbuf); // zeroed by calloc
   if (client->opt->curl_proxy) {
     DLOG_REQ("Using curl proxy: %s", client->opt->curl_proxy);
     ASSERT_CURL_EASY_SETOPT(ctx, CURLOPT_PROXY, client->opt->curl_proxy);
@@ -303,6 +304,9 @@ static int https_fetch_ctx_process_response(https_client_t *client,
       break;
     default:
       ELOG_REQ("curl request failed with %d: %s", res, curl_easy_strerror(res));
+      if (ctx->curl_errbuf[0] != 0) {
+        ELOG_REQ("curl error message: %s", ctx->curl_errbuf);
+      }
   }
 
   if ((res = curl_easy_getinfo(

--- a/src/https_client.h
+++ b/src/https_client.h
@@ -14,6 +14,7 @@ typedef void (*https_response_cb)(void *data, char *buf, size_t buflen);
 // Internal: Holds state on an individual transfer.
 struct https_fetch_ctx {
   CURL *curl;
+  char curl_errbuf[CURL_ERROR_SIZE];
 
   uint16_t id;
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -12,7 +12,7 @@ static FILE *logf = NULL;        // NOLINT(cppcoreguidelines-avoid-non-const-glo
 static int loglevel = LOG_ERROR; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static ev_timer logging_timer;   // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-static const char *SeverityStr[] = {
+static const char * const SeverityStr[] = {
   "[D]",
   "[I]",
   "[W]",
@@ -63,6 +63,7 @@ int logging_debug_enabled() {
   return loglevel <= LOG_DEBUG;
 }
 
+// NOLINTNEXTLINE(misc-no-recursion) because of severity check
 void _log(const char *file, int line, int severity, const char *fmt, ...) {
   if (severity < loglevel) {
     return;

--- a/src/main.c
+++ b/src/main.c
@@ -17,21 +17,23 @@
 #include "stat.h"
 
 // Holds app state required for dns_server_cb.
+// NOLINTNEXTLINE(altera-struct-pack-align)
 typedef struct {
   https_client_t *https_client;
   struct curl_slist *resolv;
   const char *resolver_url;
-  uint8_t using_dns_poller;
   stat_t *stat;
+  uint8_t using_dns_poller;
 } app_state_t;
 
+// NOLINTNEXTLINE(altera-struct-pack-align)
 typedef struct {
-  uint16_t tx_id;
-  struct sockaddr_storage raddr;
   dns_server_t *dns_server;
   char* dns_req;
-  ev_tstamp start_tstamp;
   stat_t *stat;
+  ev_tstamp start_tstamp;
+  uint16_t tx_id;
+  struct sockaddr_storage raddr;
 } request_t;
 
 // Very very basic hostname parsing.

--- a/src/options.c
+++ b/src/options.c
@@ -180,7 +180,7 @@ void options_show_usage(int __attribute__((unused)) argc, char **argv) {
          "                         (Default: %d, Min: 5, Max: 3600)\n",
          defaults.bootstrap_dns_polling_interval);
   printf("  -4                     Force IPv4 hostnames for DNS resolvers non IPv6 networks.\n");
-  printf("  -r resolver_url        The HTTPS path to the resolver URL. default: %s\n",
+  printf("  -r resolver_url        The HTTPS path to the resolver URL. Default: %s\n",
          defaults.resolver_url);
   printf("  -t proxy_server        Optional HTTP proxy. e.g. socks5://127.0.0.1:1080\n");
   printf("                         Remote name resolution will be used if the protocol\n");
@@ -196,7 +196,9 @@ void options_show_usage(int __attribute__((unused)) argc, char **argv) {
   printf("  -s statistic_interval  Optional statistic printout interval.\n"\
          "                         (Default: %d, Disabled: 0, Min: 1, Max: 3600)\n",
          defaults.stats_interval);
-  printf("  -v                     Increase logging verbosity. (INFO)\n");
+  printf("  -v                     Increase logging verbosity. (Default: error)\n");
+  printf("                         Levels: fatal, stats, error, warning, info, debug\n");
+  printf("                         Request issues are logged on warning level.\n");
   printf("  -V                     Print version and exit.\n");
   printf("  -h                     Print help and exit.\n");
   options_cleanup(&defaults);

--- a/src/stat.c
+++ b/src/stat.c
@@ -55,6 +55,7 @@ void stat_request_end(stat_t *s, size_t resp_len, ev_tstamp latency)
   if (resp_len) {
     s->responses_size += resp_len;
     s->responses++;
+    // NOLINTNEXTLINE(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
     s->query_times_sum += (latency * 1000);
   }
 }


### PR DESCRIPTION
Hi,
please welcome my next pack of fixes:

1. gcc-10 and clang-12 warning fixes with github actions
2. Limiting response body size to avoid dealing with non-standard large invalid responses
3. Better curl result checking, since the most important curl error code was not checked yet and also the usefull curl error message is printed as well to help users debug issues
4. HTTP request errors now printed on warning level. (curl API errors are still on error level)
#125 
5. minor changes: condition removed when setting curlpipe option and shutdown on SIGTERM (I can't belive, that this was missing. I did not even noticed 😄)

As always: I have tested my changes in my own server.

I hope, you will like it.
Sincerely,
Balázs

Spoiler: I have 2 branch WIP in my repo: HTTP/3 support and robot functional testing.