### PR TITLE
Allow building in another directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ endif()
 
 configure_file(${TARGET_NAME}.service.in ${TARGET_NAME}.service)
 
-install(FILES ${TARGET_NAME}.service
+install(FILES ${CMAKE_BINARY_DIR}/${TARGET_NAME}.service
         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system/)
 
 # TESTING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "Setting build type to '${CMAKE_BUILD_TYPE}' as none was specified.")
 endif()
 
+if (NOT CMAKE_INSTALL_BINDIR)
+  set(CMAKE_INSTALL_BINDIR bin)
+endif()
+
 set(CMAKE_C_FLAGS "-Wall -Wextra --pedantic -Wno-strict-aliasing -Wno-variadic-macros")
 set(CMAKE_C_FLAGS_DEBUG "-g -DDEBUG")
 set(CMAKE_C_FLAGS_RELEASE "-O2")
@@ -98,7 +102,7 @@ endif()
 
 # INSTALL
 
-install(TARGETS ${TARGET_NAME} DESTINATION bin)
+install(TARGETS ${TARGET_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 set(SERVICE_EXTRA_OPTIONS "")
 if(IS_DIRECTORY "/etc/munin/plugins" AND


### PR DESCRIPTION
A very minor change. This PR allows building using CMake in a subdirectory, as customary not to pollute the main project folder with temporary build files, like so:

```
mkdir build
cd build
cmake ..
make
sudo make install
```

Currently the install step fails, as it understands the .service file is specified relative to the source folder:
```
marcos@raspberrypi:~/https_dns_proxy/build $ sudo make install
[sudo] password for marcos:
[100%] Built target https_dns_proxy
Install the project...
-- Install configuration: "Release"
-- Up-to-date: /usr/local/bin/https_dns_proxy
CMake Error at cmake_install.cmake:70 (file):
  file INSTALL cannot find
  "/home/marcos/https_dns_proxy/https_dns_proxy.service": No such file or directory.

make: *** [Makefile:126: install] Error 1
```

This only adds the option of building inside another directory - building inside the project path as specified in the readme also still works.