### PR TITLE
Fixes 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ rules.ninja
 log.html
 output.xml
 report.html
+custom_curl/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,17 @@ endif()
 # LIBRARY DEPENDENCIES
 
 find_path(LIBCARES_INCLUDE_DIR ares.h)
-find_path(LIBCURL_INCLUDE_DIR curl/curl.h)
 find_path(LIBEV_INCLUDE_DIR ev.h)
+
+if(CUSTOM_LIBCURL_INSTALL_PATH)
+  message(STATUS "Using custom libcurl from: ${CUSTOM_LIBCURL_INSTALL_PATH}")
+  set(LIBCURL_INCLUDE_DIR "${CUSTOM_LIBCURL_INSTALL_PATH}/include")
+  link_directories(BEFORE "${CUSTOM_LIBCURL_INSTALL_PATH}/lib")
+else()
+  message(STATUS "Using system libcurl")
+  find_path(LIBCURL_INCLUDE_DIR curl/curl.h)
+endif()
+
 include_directories(
   ${LIBCARES_INCLUDE_DIR} ${LIBCURL_INCLUDE_DIR}
   ${LIBEV_INCLUDE_DIR} src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ set(SRC_LIST ${SRC_LIST})
 add_executable(${TARGET_NAME} ${SRC_LIST})
 set(LIBS ${LIBS} cares curl ev resolv)
 target_link_libraries(${TARGET_NAME} ${LIBS})
+set_property(TARGET ${TARGET_NAME} PROPERTY C_STANDARD 11)
 
 define_file_basename_for_sources("https_dns_proxy")
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ $ cmake .
 $ make
 ```
 
+### Build with HTTP/3 support
+
+* If system libcurl supports it by default nothing else has to be done
+
+* If a custom build of libcurl supports HTTP/3 which is installed in a different location, that can be set when running cmake:
+```
+$ cmake -D CUSTOM_LIBCURL_INSTALL_PATH=/absolute/path/to/custom/libcurl/install .
+```
+
+* Just to test HTTP/3 support for development purpose, simply run the following command and wait for a long time:
+```
+$ ./development_build_with_http3.sh
+```
+
 ## INSTALL
 
 ### Install built program

--- a/development_build_with_http3.sh
+++ b/development_build_with_http3.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+echo
+echo "WARNING !!!"
+echo
+echo "Use only for development and testing!"
+echo "It is highly highly not recommended, to use in production!"
+echo "This script was based on: https://github.com/curl/curl/blob/curl-7_82_0/docs/HTTP3.md"
+echo
+
+sleep 5
+
+INSTALL_DIR=$PWD/custom_curl/install
+mkdir -p $INSTALL_DIR
+cd custom_curl
+
+###
+
+git clone --depth 1 -b openssl-3.0.0+quic https://github.com/quictls/openssl
+cd openssl
+./config enable-tls1_3 --prefix=$INSTALL_DIR
+make -j build_libs
+make install_dev
+cd ..
+
+git clone --depth 1 -b v0.3.0 https://github.com/ngtcp2/nghttp3
+cd nghttp3
+autoreconf -fi
+./configure --prefix=$INSTALL_DIR --enable-lib-only
+make -j
+make install
+cd ..
+
+git clone --depth 1 -b v0.3.1 https://github.com/ngtcp2/ngtcp2
+cd ngtcp2
+autoreconf -fi
+./configure PKG_CONFIG_PATH=$INSTALL_DIR/lib64/pkgconfig:$INSTALL_DIR/lib64/pkgconfig LDFLAGS="-Wl,-rpath,$INSTALL_DIR/lib64" --prefix=$INSTALL_DIR --enable-lib-only --with-openssl
+make -j
+make install
+cd ..
+
+git clone --depth 1 -b v1.47.0 https://github.com/nghttp2/nghttp2
+cd nghttp2
+autoreconf -fi
+./configure PKG_CONFIG_PATH=$INSTALL_DIR/lib64/pkgconfig:$INSTALL_DIR/lib64/pkgconfig LDFLAGS="-Wl,-rpath,$INSTALL_DIR/lib64" --prefix=$INSTALL_DIR --enable-lib-only --with-openssl
+make -j
+make install
+cd ..
+
+git clone --depth 1 -b curl-7_82_0 https://github.com/curl/curl
+cd curl
+autoreconf -fi
+LDFLAGS="-Wl,-rpath,$INSTALL_DIR/lib64" ./configure --with-openssl=$INSTALL_DIR --with-nghttp2=$INSTALL_DIR --with-nghttp3=$INSTALL_DIR --with-ngtcp2=$INSTALL_DIR --prefix=$INSTALL_DIR
+make -j
+make install
+cd ..
+
+###
+
+cd ..
+cmake -D CUSTOM_LIBCURL_INSTALL_PATH=$INSTALL_DIR .
+make -j

--- a/src/main.c
+++ b/src/main.c
@@ -263,11 +263,14 @@ int main(int argc, char *argv[]) {
   dns_server_init(&dns_server, loop, opt.listen_addr, opt.listen_port,
                   dns_server_cb, &app);
 
+  if (opt.gid != (uid_t)-1 && setgroups(1, &opt.gid)) {
+    FLOG("Failed to set groups");
+  }
   if (opt.gid != (uid_t)-1 && setgid(opt.gid)) {
-    FLOG("Failed to set gid.");
+    FLOG("Failed to set gid");
   }
   if (opt.uid != (uid_t)-1 && setuid(opt.uid)) {
-    FLOG("Failed to set uid.");
+    FLOG("Failed to set uid");
   }
 
   if (opt.daemonize) {


### PR DESCRIPTION
Hi,

only 2 things for now:

1. Fixes for issue #140
2. Added simple script (development_build_with_http3.sh) to have a (lib)curl build with HTTP/3 and HTTP/2 support for testing and development purpose.
Usage is easy, detailed in README.md Build chapter.

Thanks,
Balázs