### PR TITLE
Option to pass CA_INFO through to curl

### DIFF
--- a/src/https_client.c
+++ b/src/https_client.c
@@ -320,6 +320,9 @@ static void https_fetch_ctx_init(https_client_t *client,
     DLOG_REQ("Using curl proxy: %s", client->opt->curl_proxy);
     ASSERT_CURL_EASY_SETOPT(ctx, CURLOPT_PROXY, client->opt->curl_proxy);
   }
+  if (client->opt->ca_info) {
+    ASSERT_CURL_EASY_SETOPT(ctx, CURLOPT_CAINFO, client->opt->ca_info);
+  }
   CURLMcode multi_code = curl_multi_add_handle(client->curlm, ctx->curl);
   if (multi_code != CURLM_OK) {
     FLOG_REQ("curl_multi_add_handle error %d: %s",

--- a/src/options.c
+++ b/src/options.c
@@ -41,7 +41,7 @@ void options_init(struct Options *opt) {
 
 int options_parse_args(struct Options *opt, int argc, char **argv) {
   int c = 0;
-  while ((c = getopt(argc, argv, "a:c:p:du:g:b:i:4r:e:t:l:vxqs:hV")) != -1) {
+  while ((c = getopt(argc, argv, "a:c:p:du:g:b:i:4r:e:t:l:vxqs:C:hV")) != -1) {
     switch (c) {
     case 'a': // listen_addr
       opt->listen_addr = optarg;
@@ -96,6 +96,9 @@ int options_parse_args(struct Options *opt, int argc, char **argv) {
       break;
     case 's': // stats interval
       opt->stats_interval = atoi(optarg);
+      break;
+    case 'C': // CA info
+      opt->ca_info = optarg;
       break;
     case '?':
       printf("Unknown option '-%c'\n", c);
@@ -206,6 +209,8 @@ void options_show_usage(int __attribute__((unused)) argc, char **argv) {
   printf("  -s statistic_interval  Optional statistic printout interval.\n"\
          "                         (Default: %d, Disabled: 0, Min: 1, Max: 3600)\n",
          defaults.stats_interval);
+  printf("  -C path                Optional directory containing CA "
+         "certificates.\n");
   printf("  -v                     Increase logging verbosity. (Default: error)\n");
   printf("                         Levels: fatal, stats, error, warning, info, debug\n");
   printf("                         Request issues are logged on warning level.\n");

--- a/src/options.c
+++ b/src/options.c
@@ -209,8 +209,7 @@ void options_show_usage(int __attribute__((unused)) argc, char **argv) {
   printf("  -s statistic_interval  Optional statistic printout interval.\n"\
          "                         (Default: %d, Disabled: 0, Min: 1, Max: 3600)\n",
          defaults.stats_interval);
-  printf("  -C path                Optional directory containing CA "
-         "certificates.\n");
+  printf("  -C path                Optional file containing CA certificates.\n");
   printf("  -v                     Increase logging verbosity. (Default: error)\n");
   printf("                         Levels: fatal, stats, error, warning, info, debug\n");
   printf("                         Request issues are logged on warning level.\n");

--- a/src/options.h
+++ b/src/options.h
@@ -48,6 +48,9 @@ struct Options {
 
   // Print statistic interval
   int stats_interval;
+
+  // Path to a file containing CA certificates
+  const char *ca_info;
 };
 typedef struct Options options_t;
 


### PR DESCRIPTION
This adds a commandline option to pass additional CA certificates through to curl. 