### PR TITLE
Properly initialize new ca_info option

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -37,6 +37,7 @@ void options_init(struct Options *opt) {
   opt->curl_proxy = NULL;
   opt->use_http_version = DEFAULT_HTTP_VERSION;
   opt->stats_interval = 0;
+  opt->ca_info = NULL;
 }
 
 int options_parse_args(struct Options *opt, int argc, char **argv) {


### PR DESCRIPTION
Otherwise, this can wind up being a garbage non-NULL value that breaks cURL's ability to perform certificate verification:

curl error message: error setting certificate verify locations:  CAfile: �� CApath: none

Fixes #144.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>