### PR TITLE
Add support for large responses

### DIFF
--- a/src/https_client.c
+++ b/src/https_client.c
@@ -13,7 +13,10 @@
 #include "options.h"
 
 #define DOH_CONTENT_TYPE "application/dns-message"
+
+#ifndef DOH_MAX_RESPONSE_SIZE
 #define DOH_MAX_RESPONSE_SIZE 65535
+#endif
 
 // the following macros require to have ctx pointer to https_fetch_ctx structure
 // else: compilation failure will occur


### PR DESCRIPTION
Quick and dirty; the recursive call to `dns_server_respond` may not be to everybody's taste.