### PR TITLE
Remove unnecessary math.h import

### DIFF
--- a/src/dns_poller.c
+++ b/src/dns_poller.c
@@ -1,4 +1,3 @@
-#include <math.h>        // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <netdb.h>       // NOLINT(llvmlibc-restrict-system-libc-headers)
 #include <string.h>      // NOLINT(llvmlibc-restrict-system-libc-headers)
 


### PR DESCRIPTION
This import does not seem to be required, and causes compilation issues in a Buildroot ARM64 environment during clang-tidy