### PR TITLE
Fixes 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ define_file_basename_for_sources("https_dns_proxy")
 
 if(SW_VERSION)
   set_source_files_properties(
-    src/options.c
+    src/main.c
     PROPERTIES COMPILE_FLAGS "-DSW_VERSION='\"${SW_VERSION}\"'")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ only makes sense if you trust your DoH provider.
 
 ## Build
 
-Depends on `c-ares (>=1.11.0)`, `libcurl (>=7.65.0)`, `libev (>=4.25)`.
+Depends on `c-ares (>=1.11.0)`, `libcurl (>=7.66.0)`, `libev (>=4.25)`.
 
 On Debian-derived systems those are libc-ares-dev,
 libcurl4-{openssl,nss,gnutls}-dev and libev-dev respectively.
@@ -208,7 +208,7 @@ Usage: ./https_dns_proxy [-a <listen_addr>] [-p <listen_port>]
   -F log_limit           Flight recorder: storing desired amount of logs from all levels
                          in memory and dumping them on fatal error or on SIGUSR2 signal.
                          (Default: 0, Disabled: 0, Min: 100, Max: 100000)
-  -V                     Print version and exit.
+  -V                     Print versions and exit.
   -h                     Print help and exit.
 ```
 

--- a/src/https_client.c
+++ b/src/https_client.c
@@ -235,10 +235,8 @@ static const char * http_version_str(const long version) {
     case CURL_HTTP_VERSION_2_0: // fallthrough
     case CURL_HTTP_VERSION_2TLS:
       return "2";
-#ifdef CURL_VERSION_HTTP3
     case CURL_HTTP_VERSION_3:
       return "3";
-#endif
     default:
       FLOG("Unsupported HTTP version: %d", version);
   }
@@ -255,9 +253,7 @@ static void https_set_request_version(https_client_t *client,
     case 2:
       break;
     case 3:
-#ifdef CURL_VERSION_HTTP3
       http_version_int = CURL_HTTP_VERSION_3;
-#endif
       break;
     default:
       FLOG_REQ("Invalid HTTP version: %d", client->opt->use_http_version);

--- a/src/options.h
+++ b/src/options.h
@@ -59,12 +59,19 @@ struct Options {
 } __attribute__((aligned(128)));
 typedef struct Options options_t;
 
+enum OptionsParseResult {
+    OPR_SUCCESS,
+    OPR_HELP,
+    OPR_VERSION,
+    OPR_OPTION_ERROR,
+    OPR_PARSING_ERROR
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-const char * options_sw_version(void);
 void options_init(struct Options *opt);
-int options_parse_args(struct Options *opt, int argc, char **argv);
+enum OptionsParseResult options_parse_args(struct Options *opt, int argc, char **argv);
 void options_show_usage(int argc, char **argv);
 void options_cleanup(struct Options *opt);
 #ifdef __cplusplus

--- a/src/ring_buffer.h
+++ b/src/ring_buffer.h
@@ -1,5 +1,5 @@
-#ifndef _FR_H_
-#define _FR_H_
+#ifndef _RING_BUFFER_H_
+#define _RING_BUFFER_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -18,4 +18,4 @@ void ring_buffer_push_back(struct ring_buffer *rb, char* data, uint32_t size);
 }
 #endif
 
-#endif // _FR_H_
+#endif // RING_BUFFER_H_


### PR DESCRIPTION
Hi Aaron,
I hope you are doing well! Here is nothing special, just the usual: a few code changes.

1. Fixing ring_buffer.h define of my previous pull request
2. To improve debugging, now I set to log HTTPS request and response content (so the DNS request and reply) as well on debug level. I hope this could help debugging future issues. Obviously users still can decide not to share these lines when opening an issue here.
3. I have improved the version printing to fix #183 As I implemented it, I tried to improve the code a bit. (switch-case of options_parse_args() got a bit large, but I tried to make it clean and simple :S)
Example printout:
```
$ ./https_dns_proxy -V
2025.05.10-20a4f43
Using: ev/4.33 c-ares/1.33.0 libcurl/8.12.1-DEV quictls/3.1.4 zlib/1.3.1 brotli/1.1.0 zstd/1.5.6 libidn2/2.3.7 libpsl/0.21.2 nghttp2/1.64.0 ngtcp2/1.2.0 nghttp3/1.1.0 librtmp/2.3
Features: HTTP2 HTTP3 HTTPS-proxy IPv6
```

Take your time.
Best regards,
Balázs